### PR TITLE
Correct README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ I'm Mine-Alex, creator of TownyBattle. I created this plugin in order to have mo
 Towny Battle - This plugin is designed for fighting on minecraft servers where [Towny](https://github.com/TownyAdvanced/Towny) is pre-installed.
 Management is carried out by the server administration, which has 'battleAdmin' rights.
 
-Check out some of Towny Battle's features and see for yourself why it's so great.**
+Check out some of Towny Battle's features and see for yourself why it's so great.
 </p>
 
 ___
@@ -40,27 +40,24 @@ ___
 ### Staying up to date
 <p><img align=right src="https://user-images.githubusercontent.com/879756/65964779-3a067200-e423-11e9-9928-938b976af2c2.gif" height="155">
     
-Now that all Release builds and Development builds are being made available here on github's [Releases](https://github.com/TownyAdvanced/Towny/releases) tab I am recommending that server admins "watch" Towny Battle on github. Just click the watch button in the upper right and select "Custom > Releases".
+Now that all Release builds and Development builds are being made available here on github's [Releases](https://github.com/Mine-Alex/TownyBattle/releases) tab I am recommending that server admins "watch" Towny Battle on github. Just click the watch button in the upper right and select "Custom > Releases".
     
-Alternatively, if you [watch the resource](https://www.spigotmc.org/resources/) on Spigot you will be notified on that website when a new Release version is out.
+Alternatively, if you [watch the resource](https://www.spigotmc.org/resources/townybattle.101931/) on Spigot you will be notified on that website when a new Release version is out.
 </p>
 
 ___
 
 ### Contributing
-If you'd like to contribute to the Towny code, see the [CONTRIBUTING.md](https://github.com/Mine-Alex/TownyBattle/blob/main/CONTRIBUTING.md).
+If you'd like to contribute to the Towny Battle code, see the [CONTRIBUTING.md](https://github.com/Mine-Alex/TownyBattle/blob/main/CONTRIBUTING.md).
 
 ___
 
 ### Translations
-If you'd like to help translating Towny into the available languages or add entirely new languages, [we're on Crowdin!](https://crowdin.com/project/towny-battle)
+If you'd like to help translating Towny Battle into the available languages or add entirely new languages, [we're on Crowdin!](https://crowdin.com/project/towny-battle)
 
 [![Crowdin](https://badges.crowdin.net/towny-battle/localized.svg)](https://crowdin.com/project/towny-battle)
 
 ___
 
 ### Licensing
-Towny is licensed under the [Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported (CC BY-NC-ND 3.0) License ](http://creativecommons.org/licenses/by-nc-nd/3.0/)
-
-We don't object to you making your own forks and builds but we do object to people being selfish, which is why we specify No Derivative Works.
-If you want to modify the code to add some nice feature the least you can do is ask and submit a pull request to allow everyone to benefit from it.
+Towny Battle is licensed under the [MIT License](https://github.com/Mine-Alex/TownyBattle/blob/main/LICENSE)


### PR DESCRIPTION
Removes old text related to Towny.
References Towny Battle where it should be referenced.
Corrects license text.